### PR TITLE
feat: also return the user response when picking window

### DIFF
--- a/lua/window-picker/init.lua
+++ b/lua/window-picker/init.lua
@@ -212,7 +212,7 @@ function M.pick_window(custom_config)
 
     v.o.laststatus = laststatus
 
-    return win_map[resp]
+    return win_map[resp], resp
 end
 
 function M.setup(custom_config)


### PR DESCRIPTION
This is to enable custom use cases where inputting a certain key should
trigger a certain action, for example going back to the previous window:

```lua
vim.keymap.set("n", "-", function ()
  local window, key = window_picker.pick_window()
  if window then
    vim.api.nvim_set_current_win(window)
  elseif key == "-" then
    vim.cmd [[wincmd p]]
  end
end)
```