### PR TITLE
feat: add fg_color config option for setting text color

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ require 'window-picker'.setup({
         file_name_contains = {},
     },
 
+    -- the foreground (text) color of the picker
+    fg_color = '#ededed',
+
     -- if you have include_current_win == true, then current_win_hl_color will
     -- be highlighted using this background color
     current_win_hl_color = '#e35e4f',

--- a/lua/window-picker/config.lua
+++ b/lua/window-picker/config.lua
@@ -47,6 +47,9 @@ local config = {
         file_name_contains = {},
     },
 
+    -- the foreground (text) color of the picker
+    fg_color = '#ededed',
+
     -- if you have include_current_win == true, then current_win_hl_color will
     -- be highlighted using this background color
     current_win_hl_color = '#e35e4f',

--- a/lua/window-picker/init.lua
+++ b/lua/window-picker/init.lua
@@ -134,11 +134,11 @@ function M.pick_window(custom_config)
     -- NOTE: somethig clears out the highlights so this needs to be in pick
     -- window function
     v.cmd(
-        'highlight NvimWindoSwitch gui=bold guifg=#ededed guibg=' ..
-            conf.current_win_hl_color)
+        ('highlight NvimWindoSwitch gui=bold guifg=%s guibg=%s'):format(conf.fg_color, conf.current_win_hl_color)
+    )
     v.cmd(
-        'highlight NvimWindoSwitchNC gui=bold guifg=#ededed guibg=' ..
-            conf.other_win_hl_color)
+        ('highlight NvimWindoSwitchNC gui=bold guifg=%s guibg=%s'):format(conf.fg_color, conf.other_win_hl_color)
+    )
 
     local selectable = nil
 


### PR DESCRIPTION
I tried to follow existing conventions, I personally think it's nice when you're able to override highlights the vim-way via `:highlight`.