### PR TITLE
feat: add option "selection_display" to change display

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,11 @@ require 'window-picker'.setup({
     -- all the windows except the curren window will be highlighted using this
     -- color
     other_win_hl_color = '#44cc41',
+
+    -- You can change the display string in status bar.
+    -- It supports '%' printf style. Such as `return char .. ': %f'` to display
+    -- buffer filepath. See :h 'stl' for details.
+    selection_display = function (char) return char end,
 })
 ```
 

--- a/lua/window-picker/config.lua
+++ b/lua/window-picker/config.lua
@@ -11,6 +11,11 @@ local config = {
     -- following letters on them so you can use that letter to select the window
     selection_chars = 'FJDKSLA;CMRUEIWOQP',
 
+    -- You can change the display string in status bar.
+    -- It supports '%' printf style. Such as `return char .. ': %f'` to display
+    -- buffer filepath. See :h 'stl' for details.
+    selection_display = function (char) return char end,
+
     -- whether you want to use winbar instead of the statusline
     -- "always" means to always use winbar,
     -- "never" means to never use winbar

--- a/lua/window-picker/init.lua
+++ b/lua/window-picker/init.lua
@@ -196,7 +196,7 @@ function M.pick_window(custom_config)
 
         win_map[char] = id
 
-        api.nvim_win_set_option(id, indicator_setting, '%=' .. char .. '%=')
+        api.nvim_win_set_option(id, indicator_setting, '%=' .. conf.selection_display(char) .. '%=')
 
         api.nvim_win_set_option(
             id,


### PR DESCRIPTION
By default the it displays a single letter to select the window.

If set `selection_display = function (char) return string.format('[%s] %s', char, '%f') end`, it will display `[J] README.md`.

<img width="1352" alt="CleanShot 2022-11-08 at 21 10 52@2x" src="https://user-images.githubusercontent.com/1998490/200573389-dfe93efe-476c-4e47-b6ff-8c33ad5cfa8f.png">

It also works in winbar.