### PR TITLE
Options for custom user logic

### DIFF
--- a/lua/window-picker/hints/floating-big-letter-hint.lua
+++ b/lua/window-picker/hints/floating-big-letter-hint.lua
@@ -24,7 +24,7 @@ local border = {
 	{ '│', 'FloatBorder' },
 }
 
-function M:new()
+function M:new(config)
 	local o = {
 		win = {
 			width = 18,
@@ -35,6 +35,7 @@ function M:new()
 
 	setmetatable(o, M)
 	self.__index = self
+	self.config = config
 
 	return o
 end
@@ -47,7 +48,7 @@ function M:set_config(config)
 		self.big_chars = require(('window-picker.hints.data.%s'):format(font))
 	end
 
-	if type(font) ==  'table' then
+	if type(font) == 'table' then
 		self.big_chars = font
 	end
 end
@@ -123,12 +124,29 @@ function M:_show_letter_in_window(window, char)
 end
 
 function M:draw(windows)
-	for index, window in ipairs(windows) do
-		local char = self.chars[index]
+	local windowlist = {}
+	for _, win in ipairs(windows) do
+		windowlist[win] = false
+	end
+	if self.config.pre_assign_chars then
+		windowlist = self.config.pre_assign_chars(windowlist)
+	end
+
+	local _idx = 1
+	for _win, _char in pairs(windowlist) do
+		local window = _win
+		local char = _char
+		if not char then
+			char = self.chars[_idx]
+			windowlist[_win] = char
+			_idx = _idx + 1
+		end
 		local big_char = self.big_chars[char:lower()]
 		local window_id = self:_show_letter_in_window(window, big_char)
 		table.insert(self.windows, window_id)
 	end
+
+	return windowlist
 end
 
 function M:clear()

--- a/lua/window-picker/init.lua
+++ b/lua/window-picker/init.lua
@@ -7,13 +7,14 @@ function M.pick_window(custom_config)
 	return builder
 		:new()
 		:set_config(custom_config)
-		:set_hint(FloatingHint:new())
+		:set_hint(FloatingHint:new(custom_config.hint))
 		:set_picker()
 		:set_filter()
 		:build()
 		:pick_window()
 end
 
-function M.setup() end
+function M.setup()
+end
 
 return M

--- a/lua/window-picker/pickers/window-picker.lua
+++ b/lua/window-picker/pickers/window-picker.lua
@@ -14,6 +14,7 @@ end
 
 function M:set_config(config)
 	self.chars = config.chars
+	self.process_unknown_char = config.process_unknown_char
 	self.show_prompt = config.show_prompt
 	self.prompt_message = config.prompt_message
 	self.autoselect_one = config.filter_rules.autoselect_one
@@ -60,7 +61,7 @@ function M:pick_window()
 
 	local window = nil
 
-	self.hint:draw(windows)
+	local windowlist = self.hint:draw(windows)
 
 	vim.cmd.redraw()
 
@@ -75,7 +76,16 @@ function M:pick_window()
 	self.hint:clear()
 
 	if char then
-		window = self:_find_matching_win_for_char(char, windows)
+		for w, c in pairs(windowlist) do
+			if c == (char:upper()) then
+				window = w
+			end
+		end
+		-- window = self:_find_matching_win_for_char(char, windows) or char
+	end
+
+	if not window and self.process_unknown_char then
+		window = self.process_unknown_char(char, windowlist)
 	end
 
 	return window


### PR DESCRIPTION
`hint.pre_assign_chars`: this started out as an experiment of unifying the familiar HJKL window navigation hints with the amazing features this plugin has to offer, and evolved into this generalized  option. 

`process_unknown_char`: this is required in order to handle (control-) chars not available as hints. The original intention was to quickly switch between the last 2 windows using `<C-w><C-w>`, but in its general form could cover more potential use-cases.

This is the `lazy.nvim` config I'm using with the current branch and it's working really well for me so far.

```lua
function winid_from_winnr(arg)
  local nr
  if arg then
    nr = vim.fn.winnr(arg)
  else
    nr = vim.fn.winnr()
  end
  if nr then
    return vim.fn.win_getid(nr)
  else
    return nil
  end
end

return {
  's1n7ax/nvim-window-picker',
  branch = 'release/2.0',
  keys = {
    "<C-w>"
  },
  opts = {
    hint = {

      -- Get a chance to assign keys to windows based on user-defined logic
      -- before window-picker assigns them from available selection_chars.
      -- windowlist: sparse list winid -> char (char initialized as false)
      -- Should return the updated windowlist with pre-assigned chars.
      pre_assign_chars = function(windowlist)
        -- Show H/J/K/L hints where you would expect them
        local keys = { 'h', 'j', 'k', 'l', }
        for _, k in ipairs(keys) do
          local winid = winid_from_winnr(k)
          if winid and windowlist[winid] ~= nil then
            windowlist[winid] = k:upper()
          end
        end
        return windowlist
      end,
    },

    -- Get a last chance to match a window when user presses a key not assigned in
    -- windowlist. 
    -- Returns winid for the unknown char (doesn't have to be a winid present on the
    -- windowlist - the windowlist arg is provided for completeness). Alternatively, user 
    -- can return nil and run nvim_set_current_win or any custom logic.
    process_unknown_char = function(char, windowlist)
      vim.print(windowlist)
      local cw = vim.api.nvim_replace_termcodes("<C-w>", true, true, true)
      if char == cw then
        -- always go to last window
        return winid_from_winnr("#")
      else
        -- could also nvim_set_current_win here as long as we return nil
        return nil
      end
    end,

    autoselect_one = true,
    include_current_win = false,
    selection_chars = 'FDG' .. 'UI' .. 'RET' .. 'VN' .. 'MC' .. 'WOQP',
  },
  config = function(_, opts)
    local picker = require("window-picker")
    picker.setup(opts)
    vim.keymap.set("n", "<C-w>", function()
      local win = picker.pick_window(opts)
      if (win) then
        api.nvim_set_current_win(win)
      end
    end, { desc = "Pick a window" })
  end
}
```

I understand the api for `2.0` is still in flux and things are bound to change, so please re-arrange as you see fit, as long as we maintain enough flexibility to cover use-cases like the ones outlined above. 