### PR TITLE
Add GitHub Actions CI/CD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  style:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: JohnnyMorganz/stylua-action@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          version: latest
+          # CLI arguments
+          args: --check .
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: lunarmodules/luacheck@v1
+  release:
+    name: release
+
+    if: ${{ github.ref == 'refs/heads/main' }}
+    needs:
+      - style
+      - lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v3
+        id: release
+        with:
+          token: ${{ secrets.RELEASE_TOKEN }}
+          release-type: simple
+          package-name: nvim-window-picker
+      - uses: actions/checkout@v3
+      - uses: rickstaa/action-create-tag@v1
+        if: ${{ steps.release.outputs.release_created }}
+        with:
+          tag: stable
+          message: "Current stable release: ${{ steps.release.outputs.tag_name }}"
+          tag_exists_error: false
+          force_push_tag: true


### PR DESCRIPTION
This does a few things:

1. It checks for consistent `stylua` style as I saw there was a `stylua` configuration in the root
2. It checks for no errors from `luacheck` linter since I saw `luacheck` is used here
3. It enables [Release Please](https://github.com/google-github-actions/release-please-action) which creates easy to merge release PRs that will handle bumping the version, generating change logs, and tagging new releases automatically. Basically after something is merged into `main` it will automatically make a "release PR". As more pushes are made to `main` it will continue updating that release PR with the upcoming changelog and new version number. Once you think that release is ready to be shipped, it can just be merged like any other PR!