### PR TITLE
fix: typo in nvim_set_hl

### DIFF
--- a/lua/window-picker/hints/statusline-winbar-hint.lua
+++ b/lua/window-picker/hints/statusline-winbar-hint.lua
@@ -32,11 +32,7 @@ function M:set_config(config)
 
 	if type(config.highlights.winbar.focused) == 'table' then
 		self.wb_hi = 'WindowPickerWinBar'
-		vim.api.nvim_set_hl(
-			0,
-			self.wb_hi,
-			config.highlights.statusline.focused
-		)
+		vim.api.nvim_set_hl(0, self.wb_hi, config.highlights.statusline.focused)
 	end
 
 	if type(config.highlights.winbar.unfocused) == 'table' then

--- a/lua/window-picker/hints/statusline-winbar-hint.lua
+++ b/lua/window-picker/hints/statusline-winbar-hint.lua
@@ -35,7 +35,7 @@ function M:set_config(config)
 		vim.api.nvim_set_hl(
 			0,
 			self.wb_hi,
-			config.highlights.statusline.unfocused
+			config.highlights.statusline.focused
 		)
 	end
 


### PR DESCRIPTION
Self-explanatory. Enables setting color for a focused window once again.