### PR TITLE
add ability to configure colors with highlight groups

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -2,5 +2,8 @@
     "$schema": "https://raw.githubusercontent.com/sumneko/vscode-lua/master/setting/schema.json",
     "Lua.diagnostics.globals": [
         "vim"
+    ],
+    "diagnostics.disable": [
+        "duplicate-set-field"
     ]
 }

--- a/README.md
+++ b/README.md
@@ -181,6 +181,16 @@ require('window-picker').pick_window({
 })
 ```
 
+## Theming
+
+If you just want to define the colors using Neovim Highlights, then it's totally
+possible. You can set following highlights manually.
+
+- `WindowPickerStatusLine` (currently focused window statusline highlights)
+- `WindowPickerStatusLineNC` (currently unfocused window statusline highlights)
+- `WindowPickerWinBar` (currently focused window winbar highlights)
+- `WindowPickerWinBarNC` (currently unfocused window winbar highlights)
+
 ## Breaking changes in v2.0.0
 
 _Before_: return value from `selection_display` will be wrapped by `'%='` and

--- a/dev/init.lua
+++ b/dev/init.lua
@@ -1,3 +1,6 @@
+local cwd = vim.fn.getcwd()
+vim.opt.runtimepath:prepend(cwd)
+
 --[[
 -- plugin name will be used to reload the loaded modules
 --]]
@@ -21,12 +24,75 @@ end
 
 -- executes the run method in the package
 local run_action = function()
-	require(package_name).setup()
-	local window = require(package_name).pick_window()
+	vim.cmd.messages('clear')
 
-	vim.pretty_print('>>>', window)
+	require(package_name).setup({
+		include_current_win = true,
+		picker_config = {
+			statusline_winbar_picker = {
+				use_winbar = 'always', -- "always" | "never" | "smart"
+			},
+		},
+		highlights = {
+			statusline = {
+				focused = {
+					fg = 'yellow',
+					bg = 'yellow',
+					bold = true,
+				},
+				unfocused = {
+					fg = 'yellow',
+					bg = 'yellow',
+					bold = true,
+				},
+			},
+			winbar = {
+				focused = {
+					fg = 'red',
+					bg = 'blue',
+					bold = true,
+				},
+				unfocused = {
+					fg = 'green',
+					bg = 'black',
+					bold = true,
+				},
+			},
+		},
+	})
+
+	local window = require(package_name).pick_window({
+		-- highlights = {
+		-- 	enabled = false,
+		-- 	statusline = {
+		-- 		focused = {
+		-- 			fg = 'blue',
+		-- 			bg = 'red',
+		-- 			bold = true,
+		-- 		},
+		-- 		unfocused = {
+		-- 			fg = 'black',
+		-- 			bg = 'white',
+		-- 			bold = true,
+		-- 		},
+		-- 	},
+		-- 	winbar = {
+		-- 		focused = {
+		-- 			fg = 'red',
+		-- 			bg = 'blue',
+		-- 			bold = true,
+		-- 		},
+		-- 		unfocused = {
+		-- 			fg = 'green',
+		-- 			bg = 'black',
+		-- 			bold = true,
+		-- 		},
+		-- 	},
+		-- },
+	})
 
 	if not window then
+		print('result is nil')
 		return
 	end
 

--- a/lua/window-picker/config.lua
+++ b/lua/window-picker/config.lua
@@ -91,6 +91,7 @@ local config = {
 	-- You can pass in the highlight name or a table of content to set as
 	-- highlight
 	highlights = {
+		enabled = true,
 		statusline = {
 			focused = {
 				fg = '#ededed',

--- a/lua/window-picker/hints/statusline-winbar-hint.lua
+++ b/lua/window-picker/hints/statusline-winbar-hint.lua
@@ -1,12 +1,16 @@
+local HL = {
+	st_hi = 'WindowPickerStatusLine',
+	st_hi_nc = 'WindowPickerStatusLineNC',
+	wb_hi = 'WindowPickerWinBar',
+	wb_hi_nc = 'WindowPickerWinBarNC',
+}
+
 local StatuslineHint = require('window-picker.hints.statusline-hint')
 
 ---@class StatuslineWinbarHint
----@field window_options table<string, any> window options
----@field global_options table<string, any> global options
----@field chars string[] list of chars to hint
----@field selection_display function function to customize the hint
 local M = StatuslineHint:new()
 
+---@diagnostic disable-next-line: duplicate-set-field
 function M:set_config(config)
 	self.chars = config.chars
 	self.show_prompt = config.show_prompt
@@ -15,93 +19,75 @@ function M:set_config(config)
 		config.picker_config.statusline_winbar_picker.selection_display
 	self.use_winbar = config.picker_config.statusline_winbar_picker.use_winbar
 
-	-- registering highlights
-	if type(config.highlights.statusline.focused) == 'table' then
-		self.st_hi = 'WindowPickerStatusLine'
-		vim.api.nvim_set_hl(0, self.st_hi, config.highlights.statusline.focused)
-	end
+	self.highlights = config.highlights
 
-	if type(config.highlights.statusline.unfocused) == 'table' then
-		self.st_hi_nc = 'WindowPickerStatusLineNC'
-		vim.api.nvim_set_hl(
-			0,
-			self.st_hi_nc,
-			config.highlights.statusline.unfocused
-		)
-	end
+	self.opt_cap = {
+		statusline = {
+			g = {
+				{
+					name = 'laststatus',
+					value = 2,
+				},
+				{
+					name = 'cmdheight',
+					value = 1,
+				},
+			},
+			w = { { name = 'statusline' } },
+		},
+		winbar = {
+			g = {},
+			w = { { name = 'winbar' } },
+		},
+	}
 
-	if type(config.highlights.winbar.focused) == 'table' then
-		self.wb_hi = 'WindowPickerWinBar'
-		vim.api.nvim_set_hl(0, self.wb_hi, config.highlights.statusline.focused)
-	end
+	self.opt_save = {
+		g = {},
+		w = {},
+	}
 
-	if type(config.highlights.winbar.unfocused) == 'table' then
-		self.wb_hi_nc = 'WindowPickerWinBarNC'
-		vim.api.nvim_set_hl(
-			0,
-			self.wb_hi_nc,
-			config.highlights.statusline.unfocused
-		)
+	self.hl_ns_save = {}
+
+	self.statusline_hl_ns = vim.api.nvim_create_namespace('')
+	self.winbar_hl_ns = vim.api.nvim_create_namespace('')
+
+	self:set_plugin_hl()
+end
+
+function M:create_hl(namespace, name, properties)
+	if type(properties) == 'table' then
+		vim.api.nvim_set_hl(namespace, name, properties)
 	end
 end
 
 --- Shows the characters in status line
 --- @param windows number[] windows to draw the hints on
+---@diagnostic disable-next-line: duplicate-set-field
 function M:draw(windows)
-	local use_winbar = false
+	local hint_type, hint_dhl = unpack(self:get_hint_type())
 
-	-- calculate if we should use winbar or not
-	if self.use_winbar == 'always' then
-		use_winbar = true
-	elseif self.use_winbar == 'never' then
-		use_winbar = false
-	elseif self.use_winbar == 'smart' then
-		use_winbar = vim.o.cmdheight == 0
-	end
+	local g_opts_to_cap = self.opt_cap[hint_type].g
+	local w_opts_to_cap = self.opt_cap[hint_type].w
 
-	local indicator_setting = use_winbar and 'winbar' or 'statusline'
-	local indicator_hl = use_winbar and 'WinBar' or 'StatusLine'
-
-	if not use_winbar then
-		if vim.o.laststatus ~= 2 then
-			self.global_options['laststatus'] = vim.o['laststatus']
-			vim.o.laststatus = 2
-		end
-
-		if self.show_prompt and vim.o.cmdheight < 1 then
-			self.global_options['cmdheight'] = vim.o['cmdheight']
-			vim.o.cmdheight = 1
-		end
-	end
-
-	local win_opt_to_cap = { indicator_setting, 'winhl' }
-	self:save_window_options(windows, win_opt_to_cap)
+	self:set_global_opts(g_opts_to_cap)
+	self:set_temp_hint_hl(hint_type)
 
 	for index, window in ipairs(windows) do
+		self:set_win_opts(window, w_opts_to_cap)
+		self:set_win_hl(window, hint_type)
+
 		local char = self.chars[index]
 		local display_text = self.selection_display
 				and self.selection_display(char, window)
 			or '%=' .. char .. '%='
 
-		local winhl = string.format(
-			'%s:%s,%sNC:%s',
-			indicator_hl,
-			use_winbar and self.wb_hi or self.st_hi,
-			indicator_hl,
-			use_winbar and self.wb_hi_nc or self.wb_hi
-		)
-
-		local ok, result = pcall(
-			vim.api.nvim_win_set_option,
-			window,
-			indicator_setting,
-			display_text
-		)
+		local ok, result =
+			pcall(vim.api.nvim_win_set_option, window, hint_type, display_text)
 
 		if not ok then
 			local buffer = vim.api.nvim_win_get_buf(window)
 			local message = 'Unable to set '
-				.. indicator_setting
+				.. hint_type
 				.. ' for window id::'
 				.. window
 				.. '\n'
@@ -114,12 +100,148 @@ function M:draw(windows)
 
 			vim.notify(message, vim.log.levels.WARN)
 		end
-
-		--  pcall(vim.api.nvim_win_set_option, window, 'winhl', winhl)
-		vim.wo[window]['winhl'] = winhl
 	end
 
 	vim.cmd.redraw()
+end
+
+--- clear the screen after print
+function M:clear()
+	self:restore_global_opts()
+	self:restore_win_opts()
+	self:restore_win_hl()
+end
+
+function M:set_global_opts(opts)
+	for _, opt in ipairs(opts) do
+		local curr = vim.o[opt.name]
+		vim.o[opt.name] = opt.value
+
+		table.insert(self.opt_save.g, {
+			name = opt.name,
+			value = curr,
+		})
+	end
+end
+
+function M:set_win_opts(window, opts)
+	for _, opt in ipairs(opts) do
+		table.insert(self.opt_save.w, {
+			window = window,
+			name = opt.name,
+			value = vim.wo[window][opt.name],
+		})
+
+		if opt.value then
+			vim.wo[window][opt.name] = opt.value
+		end
+	end
+end
+
+function M:restore_global_opts()
+	for index, opt in ipairs(self.opt_save.g) do
+		vim.o[opt.name] = opt.value
+		self.opt_save.g[index] = nil
+	end
+end
+
+function M:restore_win_opts()
+	for index, opt in ipairs(self.opt_save.w) do
+		vim.wo[opt.window][opt.name] = opt.value
+		self.opt_save.w[index] = nil
+	end
+end
+
+function M:get_hint_type()
+	local use_winbar = false
+
+	-- calculate if we should use winbar or not
+	if self.use_winbar == 'always' then
+		use_winbar = true
+	elseif self.use_winbar == 'never' then
+		use_winbar = false
+	elseif self.use_winbar == 'smart' then
+		use_winbar = vim.o.cmdheight == 0
+	end
+
+	if use_winbar then
+		return {
+			'winbar',
+			'WinBar',
+		}
+	end
+
+	return {
+		'statusline',
+		'StatusLine',
+	}
+end
+
+function M:set_plugin_hl()
+	self:create_hl(
+		self.statusline_hl_ns,
+		HL.st_hi,
+		self.highlights.statusline.focused
+	)
+	self:create_hl(
+		self.statusline_hl_ns,
+		HL.st_hi_nc,
+		self.highlights.statusline.unfocused
+	)
+
+	self:create_hl(self.winbar_hl_ns, HL.wb_hi, self.highlights.winbar.focused)
+
+	self:create_hl(
+		self.winbar_hl_ns,
+		HL.wb_hi_nc,
+		self.highlights.winbar.unfocused
+	)
+end
+
+function M:set_temp_hint_hl(hint_type)
+	if hint_type == 'statusline' then
+		local st_hl = self:get_hl(self.statusline_hl_ns, HL.st_hi)
+		local st_hl_nc = self:get_hl(self.statusline_hl_ns, HL.st_hi_nc)
+
+		vim.api.nvim_set_hl(self.statusline_hl_ns, 'StatusLine', st_hl)
+		vim.api.nvim_set_hl(self.statusline_hl_ns, 'StatusLineNC', st_hl_nc)
+	else
+		local wb_hl = self:get_hl(self.winbar_hl_ns, HL.wb_hi)
+		local wb_hl_nc = self:get_hl(self.winbar_hl_ns, HL.wb_hi_nc)
+
+		vim.api.nvim_set_hl(self.winbar_hl_ns, 'WinBar', wb_hl)
+		vim.api.nvim_set_hl(self.winbar_hl_ns, 'WinBarNC', wb_hl_nc)
+	end
+end
+
+function M:get_hl(namespace, name)
+	local hl = vim.api.nvim_get_hl(namespace, {
+		name = name,
+	})
+
+	if not vim.tbl_isempty(hl) then
+		return hl
+	end
+
+	return vim.api.nvim_get_hl(0, {
+		name = name,
+	})
+end
+
+function M:set_win_hl(window, hint_type)
+	if hint_type == 'statusline' then
+		vim.api.nvim_win_set_hl_ns(window, self.statusline_hl_ns)
+	else
+		vim.api.nvim_win_set_hl_ns(window, self.winbar_hl_ns)
+	end
+
+	table.insert(self.hl_ns_save, window)
+end
+
+function M:restore_win_hl()
+	for _, window in ipairs(self.hl_ns_save) do
+		vim.api.nvim_win_set_hl_ns(window, 0)
+	end
 end
 
 return M

--- a/lua/window-picker/hints/statusline-winbar-hint.lua
+++ b/lua/window-picker/hints/statusline-winbar-hint.lua
@@ -54,7 +54,7 @@ function M:set_config(config)
 	self:set_plugin_hl()
 end
 
-function M:create_hl(namespace, name, properties)
+function M.create_hl(namespace, name, properties)
 	if type(properties) == 'table' then
 		vim.api.nvim_set_hl(namespace, name, properties)
 	end
@@ -64,7 +64,7 @@ end
 --- @param windows number[] windows to draw the hints on
 ---@diagnostic disable-next-line: duplicate-set-field
 function M:draw(windows)
-	local hint_type, hint_dhl = unpack(self:get_hint_type())
+	local hint_type = unpack(self:get_hint_type())
 
 	local g_opts_to_cap = self.opt_cap[hint_type].g
 	local w_opts_to_cap = self.opt_cap[hint_type].w
@@ -178,20 +178,20 @@ function M:get_hint_type()
 end
 
 function M:set_plugin_hl()
-	self:create_hl(
+	M.create_hl(
 		self.statusline_hl_ns,
 		HL.st_hi,
 		self.highlights.statusline.focused
 	)
-	self:create_hl(
+	M.create_hl(
 		self.statusline_hl_ns,
 		HL.st_hi_nc,
 		self.highlights.statusline.unfocused
 	)
 
-	self:create_hl(self.winbar_hl_ns, HL.wb_hi, self.highlights.winbar.focused)
+	M.create_hl(self.winbar_hl_ns, HL.wb_hi, self.highlights.winbar.focused)
 
-	self:create_hl(
+	M.create_hl(
 		self.winbar_hl_ns,
 		HL.wb_hi_nc,
 		self.highlights.winbar.unfocused
@@ -200,21 +200,21 @@ end
 
 function M:set_temp_hint_hl(hint_type)
 	if hint_type == 'statusline' then
-		local st_hl = self:get_hl(self.statusline_hl_ns, HL.st_hi)
-		local st_hl_nc = self:get_hl(self.statusline_hl_ns, HL.st_hi_nc)
+		local st_hl = M.get_hl(self.statusline_hl_ns, HL.st_hi)
+		local st_hl_nc = M.get_hl(self.statusline_hl_ns, HL.st_hi_nc)
 
 		vim.api.nvim_set_hl(self.statusline_hl_ns, 'StatusLine', st_hl)
 		vim.api.nvim_set_hl(self.statusline_hl_ns, 'StatusLineNC', st_hl_nc)
 	else
-		local wb_hl = self:get_hl(self.winbar_hl_ns, HL.wb_hi)
-		local wb_hl_nc = self:get_hl(self.winbar_hl_ns, HL.wb_hi_nc)
+		local wb_hl = M.get_hl(self.winbar_hl_ns, HL.wb_hi)
+		local wb_hl_nc = M.get_hl(self.winbar_hl_ns, HL.wb_hi_nc)
 
 		vim.api.nvim_set_hl(self.winbar_hl_ns, 'WinBar', wb_hl)
 		vim.api.nvim_set_hl(self.winbar_hl_ns, 'WinBarNC', wb_hl_nc)
 	end
 end
 
-function M:get_hl(namespace, name)
+function M.get_hl(namespace, name)
 	local hl = vim.api.nvim_get_hl(namespace, {
 		name = name,
 	})

--- a/lua/window-picker/init.lua
+++ b/lua/window-picker/init.lua
@@ -41,6 +41,71 @@ function M.setup(opts)
 	if opts then
 		dconfig = vim.tbl_deep_extend('force', dconfig, opts)
 	end
+
+	-- Setting highlights at global level
+	-- highlight config is deleted so hint classes will only receive the
+	-- highlights from config passed to pick_window() function explicitly
+	--
+	-- Behaviour:
+	-- WHEN user wants nether global nor default config, highlights can be
+	-- disabled
+	--
+	-- WHEN global highlights are already set,
+	--	IF pick_window() has no highlight config
+	--		EXPECTED to use global highlights
+	--	IF pick_window({highlights}) has highlight config
+	--		EXPECTED to override only the passed highlights ONLY
+	--
+	-- WHEN global highlights are NOT set
+	--	IF pick_window() has no highlight config
+	--		EXPECTED to use default config highlights
+	--	IF pick_window({highlights}) has highlight config
+	--		EXPECTED to override only the passed highlights ONLY
+
+	if not dconfig.highlights.enabled then
+		return
+	end
+
+	M._create_hl_if_not_exists(
+		'WindowPickerStatusLine',
+		dconfig.highlights.statusline.focused
+	)
+
+	M._create_hl_if_not_exists(
+		'WindowPickerStatusLineNC',
+		dconfig.highlights.statusline.unfocused
+	)
+
+	M._create_hl_if_not_exists(
+		'WindowPickerWinBar',
+		dconfig.highlights.winbar.focused
+	)
+
+	M._create_hl_if_not_exists(
+		'WindowPickerWinBarNC',
+		dconfig.highlights.winbar.unfocused
+	)
+
+	dconfig.highlights = {
+		statusline = {},
+		winbar = {},
+	}
+end
+
+function M._create_hl_if_not_exists(name, properties)
+	if type(properties) ~= 'table' then
+		return
+	end
+
+	local hl = vim.api.nvim_get_hl(0, {
+		name = name,
+	})
+
+	if not vim.tbl_isempty(hl) then
+		return
+	end
+
+	vim.api.nvim_set_hl(0, name, properties)
 end
 
 return M

--- a/lua/window-picker/util.lua
+++ b/lua/window-picker/util.lua
@@ -27,10 +27,16 @@ function M.map_find(tbl, match_func)
 end
 
 function M.get_user_input_char()
-	local c = vim.fn.getchar()
+	local ok, c = pcall(vim.fn.getchar)
+
+	if not ok then
+		return
+	end
+
 	while type(c) ~= 'number' do
 		c = vim.fn.getchar()
 	end
+
 	return vim.fn.nr2char(c)
 end
 

--- a/tests/core/init_spec.lua
+++ b/tests/core/init_spec.lua
@@ -1,0 +1,92 @@
+local function get_hl(name)
+	return vim.api.nvim_get_hl(0, {
+		name = name,
+	})
+end
+
+describe('core::', function()
+	describe('setup', function()
+		it('default highlights are set when setup', function()
+			local highlights = {
+				{
+					name = 'WindowPickerStatusLine',
+					expected = {
+						fg = tonumber('ededed', 16),
+						bg = tonumber('e35e4f', 16),
+						bold = true,
+						cterm = {
+							bold = true,
+						},
+					},
+				},
+				{
+					name = 'WindowPickerStatusLineNC',
+					expected = {
+						fg = tonumber('ededed', 16),
+						bg = tonumber('44cc41', 16),
+						bold = true,
+						cterm = {
+							bold = true,
+						},
+					},
+				},
+				{
+					name = 'WindowPickerWinBar',
+					expected = {
+						fg = tonumber('ededed', 16),
+						bg = tonumber('e35e4f', 16),
+						bold = true,
+						cterm = {
+							bold = true,
+						},
+					},
+				},
+				{
+					name = 'WindowPickerWinBarNC',
+					expected = {
+						fg = tonumber('ededed', 16),
+						bg = tonumber('44cc41', 16),
+						bold = true,
+						cterm = {
+							bold = true,
+						},
+					},
+				},
+			}
+			for _, hl in ipairs(highlights) do
+				assert(vim.tbl_isempty(get_hl(hl.name)))
+			end
+
+			require('window-picker').setup()
+
+			for _, hl in ipairs(highlights) do
+				assert(vim.deep_equal(hl.expected, get_hl(hl.name)))
+			end
+		end)
+
+		it(
+			'ignores setting default highlights when hl are already present',
+			function()
+				local highlights = {
+					{
+						name = 'WindowPickerStatusLine',
+						expected = {
+							fg = tonumber('4287f5', 16),
+							bg = tonumber('63f542', 16),
+						},
+					},
+				}
+
+				for _, hl in ipairs(highlights) do
+					vim.api.nvim_set_hl(0, hl.name, hl.expected)
+				end
+
+				require('window-picker').setup()
+
+				for _, hl in ipairs(highlights) do
+					assert(vim.deep_equal(get_hl(hl.name), hl.expected))
+				end
+			end
+		)
+	end)
+end)

--- a/tests/minimal.vim
+++ b/tests/minimal.vim
@@ -1,0 +1,3 @@
+set rtp+=.
+set rtp+=../plenary.nvim
+runtime! plugin/plenary.vim


### PR DESCRIPTION
## Highlighting

### Using setup configuration
```lua
require(package_name).setup({
        highlights = {
	        statusline = {
		        focused = {
			        fg = 'white',
			        bg = '#1f1f1f',
			        bold = true,
		        },
		        unfocused = {
			        fg = 'white',
			        bg = 'black',
			        bold = true,
		        },
	        },
	        winbar = {
		        focused = {
			        fg = 'white',
			        bg = '#1f1f1f',
			        bold = true,
		        },
		        unfocused = {
			        fg = 'white',
			        bg = 'black',
			        bold = true,
		        },
	        },
        },
})
```
### Using global highlights

```lua
vim.api.nvim_set_hl(0, 'WindowPickerStatusLine', { fg = 'white' })
vim.api.nvim_set_hl(0, 'WindowPickerStatusLineNC', { fg = 'white' })
vim.api.nvim_set_hl(0, 'WindowPickerWinBar', { fg = 'white' })
vim.api.nvim_set_hl(0, 'WindowPickerWinBarNC', { fg = 'white' })
```

### Using pick_window()

```lua
require('window-picker').pick_window({
        highlights = {
                .....
        },
})
```

### Using selection_display property

```lua
vim.api.nvim_set_hl(0, 'TEST', {
        fg = '#f54269',
        bg = '#1f1f1f',
})

require('window-picker').pick_window({
        picker_config = {
	        statusline_winbar_picker = {
		        selection_display = function(char)
			        return '%#TEST#' .. '%=' .. char .. '%='
		        end,
        
		        use_winbar = 'always',
	        },
        },
})
```

