### PR TITLE
fix(floating-big-letter): calculate max width

### DIFF
--- a/lua/window-picker/hints/floating-big-letter-hint.lua
+++ b/lua/window-picker/hints/floating-big-letter-hint.lua
@@ -100,7 +100,10 @@ function M:_show_letter_in_window(window, char)
 
 	local lines = self._add_big_char_margin(vim.split(char, '\n'))
 
-	local width = utf8.len(lines[2])
+	local width = 0
+	for _, line in ipairs(lines) do
+		width = math.max(width, utf8.len(line))
+	end
 	local height = #lines
 
 	local buffer_id = vim.api.nvim_create_buf(false, true)


### PR DESCRIPTION
Instead of calculating width based on 2nd index of a line, we calculate it based on the longest length instead. Without it, we have rendering issues on "wide" characters being forcibly wrapped.

This enables future support of custom fonts via `figlet` or `toilet`.

Fixes: #69

## Before
![image](https://github.com/s1n7ax/nvim-window-picker/assets/4911400/59b21b3c-7d50-4b44-9d9a-d8708e5f0f0b)

## After
![image](https://github.com/s1n7ax/nvim-window-picker/assets/4911400/3577ca5f-6e85-4ebc-bf8f-20ea0fa6d804)
