### PR TITLE
feat: add option: show_no_windows_prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ require 'window-picker'.setup({
     -- prompt message to show to get the user input
     prompt_message = 'Pick window: ',
 
+	-- whether to show 'No windows left to pick after filtering' prompt
+	show_no_windows_prompt = true,
+
     -- if you want to manually filter out the windows, pass in a function that
     -- takes two parameters. You should return window ids that should be
     -- included in the selection

--- a/lua/window-picker/config.lua
+++ b/lua/window-picker/config.lua
@@ -44,6 +44,9 @@ local config = {
 	-- prompt message to show to get the user input
 	prompt_message = 'Pick window: ',
 
+	-- whether to show 'No windows left to pick after filtering' prompt
+	show_no_windows_prompt = true,
+
 	-- if you want to manually filter out the windows, pass in a function that
 	-- takes two parameters. You should return window ids that should be
 	-- included in the selection

--- a/lua/window-picker/hints/statusline-winbar-hint.lua
+++ b/lua/window-picker/hints/statusline-winbar-hint.lua
@@ -13,6 +13,7 @@ local M = StatuslineHint:new()
 function M:set_config(config)
 	self.chars = config.chars
 	self.show_prompt = config.show_prompt
+	self.show_no_windows_prompt = config.show_no_windows_prompt
 
 	self.selection_display =
 		config.picker_config.statusline_winbar_picker.selection_display

--- a/lua/window-picker/pickers/window-picker.lua
+++ b/lua/window-picker/pickers/window-picker.lua
@@ -16,6 +16,7 @@ function M:set_config(config)
 	self.chars = config.chars
 	self.show_prompt = config.show_prompt
 	self.prompt_message = config.prompt_message
+	self.show_no_windows_prompt = config.show_no_windows_prompt
 	self.autoselect_one = config.filter_rules.autoselect_one
 	return self
 end
@@ -47,10 +48,12 @@ function M:pick_window()
 	local windows = self:_get_windows()
 
 	if #windows == 0 then
-		vim.notify(
-			'No windows left to pick after filtering',
-			vim.log.levels.WARN
-		)
+		if self.show_no_windows_prompt then
+			vim.notify(
+				'No windows left to pick after filtering',
+				vim.log.levels.WARN
+			)
+		end
 		return
 	end
 


### PR DESCRIPTION
When using nvim-tree, if there are no other windows open, an error message will be printed. Actually, this is not necessary because it will call no_window_picker(). So, I added an option to temporarily disable this when using nvim-tree.