### PR TITLE
feat: add filter for snacks notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ require 'window-picker'.setup({
         -- filter using buffer options
         bo = {
             -- if the file type is one of following, the window will be ignored
-            filetype = { 'NvimTree', 'neo-tree', 'notify' },
+            filetype = { 'NvimTree', 'neo-tree', 'notify', 'snacks_notif' },
 
             -- if the file type is one of following, the window will be ignored
             buftype = { 'terminal' },

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ require 'window-picker'.setup({
     -- You can pass in the highlight name or a table of content to set as
     -- highlight
     highlights = {
+        enabled = true,
         statusline = {
             focused = {
                 fg = '#ededed',

--- a/lua/window-picker/config.lua
+++ b/lua/window-picker/config.lua
@@ -73,7 +73,7 @@ local config = {
 		-- filter using buffer options
 		bo = {
 			-- if the file type is one of following, the window will be ignored
-			filetype = { 'NvimTree', 'neo-tree', 'notify' },
+			filetype = { 'NvimTree', 'neo-tree', 'notify', 'snacks_notif' },
 
 			-- if the file type is one of following, the window will be ignored
 			buftype = { 'terminal' },


### PR DESCRIPTION
The QoL plugin collection [Snacks by Folke](https://github.com/folke/snacks.nvim) includes a [notifier](https://github.com/folke/snacks.nvim/blob/main/docs/notifier.md#-notifier) somewhat similar to [nvim-notify](https://github.com/rcarriga/nvim-notify). This PR adds filtering for its [notification windows](https://github.com/folke/snacks.nvim/blob/main/docs/notifier.md#notification) so that they aren't picked up by window-picker.

Also adds `highlights.enabled` setting to the README which is present in `config.lua` but was missing there.