### PR TITLE
feat: add floating letter hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,10 @@ behaviour.
 require 'window-picker'.setup({
     -- type of hints you want to get
     -- following types are supported
-    -- 'statusline-winbar' | 'floating-big-letter'
+    -- 'statusline-winbar' | 'floating-big-letter' | 'floating-letter'
     -- 'statusline-winbar' draw on 'statusline' if possible, if not 'winbar' will be
     -- 'floating-big-letter' draw big letter on a floating window
+    -- 'floating-letter' draw letter on a floating window
     -- used
     hint = 'statusline-winbar',
 

--- a/lua/window-picker/hints/floating-letter-hint.lua
+++ b/lua/window-picker/hints/floating-letter-hint.lua
@@ -36,7 +36,7 @@ function M:set_config(config)
 	self.chars = config.chars
 end
 
-function M:_get_float_win_pos(window, width, height)
+function M._get_float_win_pos(window, width, height)
 	local win_width = vim.api.nvim_win_get_width(window)
 	local win_height = vim.api.nvim_win_get_height(window)
 
@@ -51,7 +51,7 @@ end
 function M:_show_letter_in_window(window, char)
 	local width = #char
 	local height = 1
-	local point = self:_get_float_win_pos(window, width, height)
+	local point = self._get_float_win_pos(window, width, height)
 
 	local buffer_id = vim.api.nvim_create_buf(false, true)
 	local window_id = vim.api.nvim_open_win(buffer_id, false, {

--- a/lua/window-picker/hints/floating-letter-hint.lua
+++ b/lua/window-picker/hints/floating-letter-hint.lua
@@ -1,0 +1,94 @@
+--- @class FloatingLetterHint
+--- @field windows number[] list of window ids
+local M = {}
+
+local border = {
+	{ '╭', 'FloatBorder' },
+
+	{ '─', 'FloatBorder' },
+
+	{ '╮', 'FloatBorder' },
+
+	{ '│', 'FloatBorder' },
+
+	{ '╯', 'FloatBorder' },
+
+	{ '─', 'FloatBorder' },
+
+	{ '╰', 'FloatBorder' },
+
+	{ '│', 'FloatBorder' },
+}
+
+function M:new()
+	local o = {
+		windows = {},
+	}
+
+	setmetatable(o, self)
+	self.__index = self
+
+	return o
+end
+
+function M:set_config(config)
+	print(vim.inspect(config))
+	self.chars = config.chars
+end
+
+function M:_get_float_win_pos(window, width, height)
+	local win_width = vim.api.nvim_win_get_width(window)
+	local win_height = vim.api.nvim_win_get_height(window)
+
+	local point = {
+		x = ((win_width - width) / 2),
+		y = ((win_height - height) / 2),
+	}
+
+	return point
+end
+
+function M:_show_letter_in_window(window, char)
+	local width = #char
+	local height = 1
+	local point = self:_get_float_win_pos(window, width, height)
+
+	local buffer_id = vim.api.nvim_create_buf(false, true)
+	local window_id = vim.api.nvim_open_win(buffer_id, false, {
+		relative = 'win',
+		win = window,
+		focusable = true,
+		row = point.y,
+		col = point.x,
+		width = width,
+		height = height,
+		style = 'minimal',
+		border = border,
+	})
+
+	vim.api.nvim_buf_set_lines(buffer_id, 0, -1, true, { char })
+
+	return window_id
+end
+
+function M:draw(windows)
+	for index, window in ipairs(windows) do
+		local char = self.chars[index]
+		local window_id = self:_show_letter_in_window(window, char)
+		table.insert(self.windows, window_id)
+	end
+end
+
+function M:clear()
+	for _, window in ipairs(self.windows) do
+		if vim.api.nvim_win_is_valid(window) then
+			local buffer = vim.api.nvim_win_get_buf(window)
+			vim.api.nvim_win_close(window, true)
+			vim.api.nvim_buf_delete(buffer, { force = true })
+		end
+	end
+
+	self.windows = {}
+end
+
+return M


### PR DESCRIPTION
When two adjacent windows with relatively low heights are next to each other, the display of big letters will overlap, making it impossible to see the letter. Therefore, I added this new kindof hint method as a candidate. 
